### PR TITLE
Use https for git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "reveal.js"]
 	path = reveal.js
-	url = git://github.com/hakimel/reveal.js.git
+	url = https://github.com/hakimel/reveal.js.git


### PR DESCRIPTION
This fixes the issue with the git submodule, [asciidoctor/asciidoctor-reveal.js#37](https://github.com/asciidoctor/asciidoctor-reveal.js/issues/37). I tried taking the error message you saw literally: it says "Make sure its using https://", so I just literally changed the protocol from `git://` to `https://`.

Note that you also have to do this for gh-pages, like I did: wackywendell/Asciidoctor_Presentation@c5b97dc6483caecb181b08b638bc81b18cf50f41 (not included in this PR). That gives you [this presentation](http://blog.lostinmyterminal.com/Asciidoctor_Presentation/). The different domain is due to domain redirection, but its still GitHub Pages hosting.

Thanks for teaching me something, too - I'm not used to using submodules, and I learned something!
